### PR TITLE
Adjust panel layout to avoid unwanted scrollbars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vercel
+node_modules/

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -6,9 +6,10 @@
     <title>Painel</title>
     <style>
       :root { color-scheme: dark; }
+      *, *::before, *::after { box-sizing: border-box; max-width:100%; word-wrap: break-word; }
       body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; background: #0f172a; color: #e5e7eb; }
-      html, body { min-width: 360px; }
-      .panel { width: 420px; max-width: 420px; max-height: 600px; display:flex; flex-direction:column; border:1px solid #1f2937; box-sizing: border-box; }
+      html, body { min-width: 360px; overflow-x: hidden; }
+      .panel { width: 100%; max-width: 420px; max-height: 600px; display:flex; flex-direction:column; border:1px solid #1f2937; overflow-x:hidden; overflow-y:auto; }
       .header { display:flex; align-items:center; justify-content:space-between; padding:10px 12px; background:#111827; border-bottom:1px solid #1f2937; }
       .title { font-weight:700; font-size:14px; }
       .body { padding:10px 12px; overflow-y:auto; overflow-x:hidden; max-height:520px; }
@@ -32,8 +33,7 @@
       .row { display:flex; flex-wrap:wrap; gap:6px; align-items:center; margin-top:8px; }
       select { padding:8px 10px; border:1px solid #334155; background:#0b1220; color:#f3f4f6; border-radius:10px; font-size:12px; flex:1 1 180px; min-width:160px; }
       .row .btn { flex: 0 0 auto; }
-      .row > label { display:inline; margin:0; white-space:nowrap; }
-      .row > label { display:inline; margin:0; white-space:nowrap; }
+      .row > label { display:inline; margin:0; white-space:normal; word-wrap: break-word; }
       .list { margin-top:8px; display:flex; flex-direction:column; gap:6px; }
       .list-item { display:flex; align-items:center; justify-content:space-between; background:#111827; border:1px solid #1f2937; border-radius:10px; padding:8px 10px; }
       .list-main { display:flex; align-items:center; gap:8px; }


### PR DESCRIPTION
## Summary
- prevent horizontal overflow in extension panel
- ensure labels and child elements wrap within panel
- ignore `node_modules` in git

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1e12f2ed88328bafe477b3416d1c6